### PR TITLE
fix#44356 link preview folder icon color updated

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -348,19 +348,21 @@ table td.filename .thumbnail-wrapper.icon-loading-small {
 	}
 }
 table td.filename .thumbnail {
-	display: inline-block;
-	width: 32px;
-	height: 32px;
-	background-size: contain;
-	background-position: center;
-	background-repeat: no-repeat;
-	margin-left: 9px;
-	margin-top: 9px;
-	border-radius: var(--border-radius);
-	cursor: pointer;
-	position: absolute;
-	z-index: 4;
+    display: inline-block;
+    width: 32px;
+    height: 32px;
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+    margin-left: 9px;
+    margin-top: 9px;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    position: absolute;
+    z-index: 4;
+    background-color: var(--primary-color); /* Set the background color to the primary color */
 }
+
 table td.filename p.name .thumbnail {
 	cursor: default;
 }

--- a/apps/files/src/views/ReferenceFileWidget.vue
+++ b/apps/files/src/views/ReferenceFileWidget.vue
@@ -55,7 +55,7 @@
 		:href="richObject.link"
 		target="_blank"
 		@click="navigate">
-		<span class="widget-file__image" :class="filePreviewClass" :style="filePreviewStyle">
+		<span class="widget-file__image" :class="filePreviewClass" :style="{ backgroundColor: primaryColor }">
 			<template v-if="!previewUrl">
 				<FolderIcon v-if="isFolder" :size="88" />
 				<FileIcon v-else :size="88" />
@@ -141,6 +141,7 @@ export default defineComponent({
 		return {
 			previewUrl: null as string | null,
 			failedViewer: false,
+			primaryColor: 'var(--primary-color)'
 		}
 	},
 


### PR DESCRIPTION
Signed-off-by: JEEEEEEEEEEEEEEEEEEEEEED <118366366+jadjoud@users.noreply.github.com>


* Resolves: # <!-- related github issue -->

## Summary

fix the previex link folder icon color

issue #44356

@jancborchardt

image
image
image

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
